### PR TITLE
chore(deps): update ghcr build/tag/push action to use main instead of…

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build, Tag and Push Docker Image to GHCR
-        uses: GlueOps/github-actions-build-push-containers@v0.1.3
+        uses: GlueOps/github-actions-build-push-containers@main


### PR DESCRIPTION
## **User description**
… being pinned to a version


___

## **Type**
enhancement


___

## **Description**
- Updated the GitHub Action used in the GHCR workflow to track the `main` branch. This change ensures that the workflow benefits from the latest updates without being pinned to a specific version.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ghcr.yaml</strong><dd><code>Update GitHub Action to Use `main` Branch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/ghcr.yaml

<li>Updated the GitHub Action for building, tagging, and pushing Docker <br>images to use the <code>main</code> branch instead of a specific version (<code>v0.1.3</code>).<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/glueops-dev/pull/65/files#diff-1c25e13ade0044334e51a0da32e5f58ab84f36f1c0f6c298a3778debab2ed163">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

