### PR TITLE
docs: add Reader Plus access tier

### DIFF
--- a/docs/deploy-applications/access-cluster-kubectl.mdx
+++ b/docs/deploy-applications/access-cluster-kubectl.mdx
@@ -6,7 +6,7 @@ type: tutorial
 
 # Access Your Cluster with kubectl
 
-You can connect to your GlueOps environment with `kubectl` using your GitHub identity — no certificates or passwords to manage. Sign-in happens through your browser, and access is scoped to your team's environment namespace at one of three permission tiers.
+You can connect to your GlueOps environment with `kubectl` using your GitHub identity — no certificates or passwords to manage. Sign-in happens through your browser, and access is scoped to your team's environment namespace at one of four permission tiers.
 
 ## Prerequisites
 
@@ -64,12 +64,13 @@ kubectl config set-context --current --namespace=CAPTAIN_NAMESPACE
 
 ## Access tiers
 
-Your permissions depend on which GitHub team you belong to. There are three tiers, each including everything from the tier above it:
+Your permissions depend on which GitHub team you belong to. There are four tiers, each including everything from the tier above it:
 
 | Tier | GitHub team | What you can do |
 |---|---|---|
 | **Reader** | <code><CaptainDomain />-kubectl-reader</code> | View pods, logs, services, deployments, ingresses, and ExternalSecrets status. No access to secret values. |
-| **Debugger** | <code><CaptainDomain />-kubectl-debugger</code> | Everything in Reader, plus: exec into pods, port-forward, attach, restart deployments, and delete stuck pods. |
+| **Reader Plus** | <code><CaptainDomain />-kubectl-reader-plus</code> | Everything in Reader, plus: port-forward to pods. |
+| **Debugger** | <code><CaptainDomain />-kubectl-debugger</code> | Everything in Reader Plus, plus: exec into pods, attach, restart deployments, and delete stuck pods. |
 | **Operator** | <code><CaptainDomain />-kubectl-operator</code> | Everything in Debugger, plus: delete any resource in your namespace. |
 
 To see which groups you signed in with, run `kubectl auth whoami`. To check whether your tier allows a specific action, run `kubectl auth can-i <verb> <resource> -n <namespace>`.


### PR DESCRIPTION
## Summary

- Adds a new **Reader Plus** tier between Reader and Debugger in the Access tiers table at `docs/deploy-applications/access-cluster-kubectl.mdx`.
- Reader Plus grants port-forward on top of read-only access. GitHub team slug: `<CaptainDomain />-kubectl-reader-plus`.
- Updates the "four permission tiers" prose and the Debugger row's parent reference to point at Reader Plus.

Companion code PR (GlueOps/tools-api#47) adds the `glueops-reader-plus` ClusterRole + RoleBinding that backs this tier. Doc description (read-only + port-forward) is verified to match the actual ClusterRole rules.

## Test plan

- [ ] Build the site locally (`npm run start` or `npm run build`) and confirm the Access tiers table renders 4 rows.
- [ ] Verify the `#access-tiers` anchor still resolves (referenced from Prerequisites and Troubleshooting sections on the same page).
- [ ] Eyeball the `<CaptainDomain />` JSX component rendering in the new Reader Plus row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)