### PR TITLE
fix: remove deleted GitHub-token docs from the sidebar (unbreak the build)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,6 +8,9 @@ map $uri $redirect_uri {
     /deploy-applications/deploy-python-app-to-glueops /deploy-applications/deploy-first-app;
     /deploy-applications/deploy-docusarus-website-to-glueops /deploy-applications/deploy-first-app;
     /deploy-applications/adding-configurations-and-secrets-to-the-hello-world-app-glueops-platform /deploy-applications/manage-environment-secrets;
+    /github-token-setup /glueops-platform-administrator/configuration/creating-github-deployment-app;
+    /glueops-platform-administrator/configuration/creating-github-token /glueops-platform-administrator/configuration/creating-github-deployment-app;
+    /glueops-platform-administrator/configuration/adding-github-token-to-organization-secrets /glueops-platform-administrator/configuration/creating-github-deployment-app;
 }
 
 # Disable robots/SEO crawling for non-prod environments

--- a/sidebars.js
+++ b/sidebars.js
@@ -108,23 +108,7 @@ const sidebars = {
           items: [
             "glueops-platform-administrator/configuration/glueops-deployment-configuration",
             "glueops-platform-administrator/configuration/export-logs",
-            {
-              type: "category",
-              label: "GitHub token setup",
-              collapsible: true,
-              items: [
-                
-                  "glueops-platform-administrator/configuration/creating-github-token",
-                  "glueops-platform-administrator/configuration/adding-github-token-to-organization-secrets"
-                
-              ],
-              link: {
-                type: "generated-index",
-                title: "Creating a GitHub token using it.",
-                description: "To enable GitHub Actions to notify our platform of code changes, we need to configure a GitHub Token as an Organization secret. These guides will walk you through setting it up:",
-                slug: "/github-token-setup",
-              },
-            }
+            "glueops-platform-administrator/configuration/creating-github-deployment-app"
 
           ],
           link: {


### PR DESCRIPTION
## Problem

`main` is broken — `yarn build` (and the Docker image build) fails:

```
Invalid sidebar file at "sidebars.js".
These sidebar document ids do not exist:
- glueops-platform-administrator/configuration/creating-github-token
- glueops-platform-administrator/configuration/adding-github-token-to-organization-secrets
```

The `deployment-configurations` App migration removed those two GitHub-token setup docs, but `sidebars.js` still referenced them.

## Fix

- **`sidebars.js`** — drop the dead "GitHub token setup" category and point the Configuration section at `creating-github-deployment-app` (the App flow that replaced the token flow, already on `main`).
- **`nginx.conf`** — add redirects from the old paths (`/github-token-setup`, `/creating-github-token`, `/adding-github-token-to-organization-secrets`) to the new doc so existing links don't 404.

## Validation

Built locally with `docker build --target build .` → **`[SUCCESS] Generated static files in "build"`** (previously failed at this step).

Scope is intentionally just these two files (nothing else vs. `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)