### PR TITLE
fix: use tls.crt/tls.key key names consistently in certbot guide

### DIFF
--- a/docs/deploy-applications/custom-domain-certificates/certbot-manual.md
+++ b/docs/deploy-applications/custom-domain-certificates/certbot-manual.md
@@ -45,8 +45,8 @@ Tips:
 In your environment's OpenBao/Vault UI (see [Managing Environment Secrets](/deploy-applications/manage-environment-secrets)), create a secret at a dedicated path:
 
 - Path: `secret/<your-app>-tls`
-- Key `tls_crt`: contents of `fullchain.pem`
-- Key `tls_key`: contents of `privkey.pem`
+- Key `tls.crt`: contents of `fullchain.pem`
+- Key `tls.key`: contents of `privkey.pem`
 
 ## Step 3 — Reference it from your application values
 
@@ -71,11 +71,11 @@ externalSecret:
         "tls.crt":
           remoteRef:
             key: secret/<your-app>-tls
-            property: tls_crt
+            property: tls.crt
         "tls.key":
           remoteRef:
             key: secret/<your-app>-tls
-            property: tls_key
+            property: tls.key
 
 ingress:
   enabled: true


### PR DESCRIPTION
Follow-up to #540: the certbot guide's vault keys and `remoteRef` properties now use `tls.crt` / `tls.key`, matching the Kubernetes TLS secret key names one-to-one instead of the `tls_crt`/`tls_key` underscore variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)