### PR TITLE
feat: add Private Registry Credentials documentation

### DIFF
--- a/docs/deploy-applications/private-registries/dockerhub.md
+++ b/docs/deploy-applications/private-registries/dockerhub.md
@@ -1,0 +1,87 @@
+---
+id: registry-dockerhub
+title: "Docker Hub (docker.io)"
+---
+
+# Pull Images from Docker Hub
+
+Deploy applications whose images live in a **private** Docker Hub repository. You store a registry credential in your environment's vault once; the platform turns it into a Kubernetes image pull secret that your workloads use automatically.
+
+:::tip Also useful for public images
+Authenticated pulls get much higher Docker Hub rate limits than anonymous ones. If your cluster pulls many public `docker.io` images and hits `429 Too Many Requests`, this same setup solves that.
+:::
+
+## Step 1 — Create an access token
+
+In Docker Hub, go to **Account Settings → Personal access tokens → Generate new token** with **Read-only** access permissions. Use a service account rather than a personal Docker ID for team-owned applications.
+
+## Step 2 — Compose the Docker config JSON
+
+Build the base64 auth string from `USERNAME:TOKEN` (your Docker ID and the token from Step 1):
+
+```bash
+printf '%s' 'my-docker-id:dckr_pat_XXXXXXXX' | base64 -w0
+```
+
+Then the credential document is (note Docker Hub's legacy auth host):
+
+```json
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "<output of the command above>"
+    }
+  }
+}
+```
+
+## Step 3 — Upload to your vault
+
+In your environment's OpenBao/Vault UI (see [Managing Environment Secrets](/deploy-applications/manage-environment-secrets)), create a secret at a dedicated path:
+
+- Path: `secret/<your-app>-registry-cred`
+- Key `.dockerconfigjson`: the JSON document from Step 2 (as a single value, including the braces)
+
+## Step 4 — Configure your application values
+
+**`base/base-values.yaml`**
+
+```yaml
+image:
+  registry: docker.io
+  repository: my-org/my-app
+  tag: v1.0.0
+  port: 8080
+  pullSecrets: my-app-registry-cred   # <app-name>-registry-cred
+```
+
+**`envs/prod/values.yaml`**
+
+```yaml
+deployment:
+  enabled: true
+  replicas: 1
+
+service:
+  enabled: true
+
+externalSecret:
+  enabled: true
+  secrets:
+    registry-cred:                     # creates Secret <app-name>-registry-cred
+      type: kubernetes.io/dockerconfigjson
+      dataFrom:
+        key: secret/<your-app>-registry-cred
+```
+
+`image.pullSecrets` is inherited by every pod template (Deployment, StatefulSet, Job, CronJob); individual workloads can override it with their own `imagePullSecrets` key if needed.
+
+## Step 5 — Deploy and verify
+
+Commit the values to your deployment-configurations repository and wait for Argo CD to sync (or click **Sync**). The `ExternalSecret` turns **Healthy** once the credential is synced, and the application pod starts normally.
+
+If the pod shows **`ImagePullBackOff`**, click it in the Argo CD resource tree and check the events:
+
+- `unauthorized: incorrect username or password` — wrong Docker ID/token pair, or the auth entry isn't under `https://index.docker.io/v1/` (Docker Hub does not match on `docker.io`).
+- `toomanyrequests` — rate limiting; confirm the pull is actually authenticated (the pull secret name matches).
+- `pull secret ... not found` — `image.pullSecrets` doesn't match the ExternalSecret's target name (`<app-name>-registry-cred`).

--- a/docs/deploy-applications/private-registries/ecr.md
+++ b/docs/deploy-applications/private-registries/ecr.md
@@ -1,0 +1,139 @@
+---
+id: registry-ecr
+title: "AWS ECR"
+---
+
+# Pull Images from AWS ECR
+
+Deploy applications whose images live in a **private Amazon ECR** repository. ECR is different from other registries: its registry tokens **expire every 12 hours**, so a static credential in the vault would stop working half a day later. Instead, the platform's external-secrets operator exchanges a long-lived (narrowly-scoped) IAM credential for a fresh ECR token on a schedule, using the [`ECRAuthorizationToken` generator](https://external-secrets.io/latest/api/generator/ecr/).
+
+## How it works
+
+1. You create a scoped IAM credential in **your** AWS account that can only pull from your ECR repositories.
+2. You store the key pair in your environment's vault; an ExternalSecret syncs it into your app's namespace.
+3. An `ECRAuthorizationToken` generator plus a second ExternalSecret (deployed through the app chart's `customResourcesMap`) exchange it for a fresh registry token every few hours and maintain the image pull secret your pods use.
+
+## Step 1 — Create a scoped IAM credential (your AWS account)
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow", "Action": "ecr:GetAuthorizationToken", "Resource": "*" },
+    { "Effect": "Allow",
+      "Action": ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer", "ecr:BatchCheckLayerAvailability"],
+      "Resource": "arn:aws:ecr:YOUR_REGION:YOUR_ACCOUNT_ID:repository/my-app*" }
+  ]
+}
+```
+
+Attach it to a dedicated IAM user (e.g. `image-pull-my-app`) and create an access key.
+
+## Step 2 — Upload the key pair to your vault
+
+In your environment's OpenBao/Vault UI (see [Managing Environment Secrets](/deploy-applications/manage-environment-secrets)), create a secret at a dedicated path:
+
+- Path: `secret/<your-app>-ecr-iam`
+- Key `access_key_id`: the Access Key ID
+- Key `secret_access_key`: the Secret Access Key
+
+## Step 3 — Configure your application values
+
+**`base/base-values.yaml`**
+
+```yaml
+image:
+  registry: YOUR_ACCOUNT_ID.dkr.ecr.YOUR_REGION.amazonaws.com
+  repository: my-app
+  tag: v1.0.0
+  port: 8080
+  pullSecrets: my-app-registry-cred   # maintained by the ExternalSecret below
+```
+
+**`envs/prod/values.yaml`**
+
+```yaml
+deployment:
+  enabled: true
+  replicas: 1
+
+service:
+  enabled: true
+
+externalSecret:
+  enabled: true
+  secrets:
+    ecr-iam:                           # creates Secret <app-name>-ecr-iam
+      data:
+        access-key-id:
+          remoteRef:
+            key: secret/<your-app>-ecr-iam
+            property: access_key_id
+        secret-access-key:
+          remoteRef:
+            key: secret/<your-app>-ecr-iam
+            property: secret_access_key
+
+customResourcesMap:
+  ecr-token-generator: |
+    apiVersion: generators.external-secrets.io/v1alpha1
+    kind: ECRAuthorizationToken
+    metadata:
+      name: my-app-ecr-token
+      namespace: {{ include "app.namespace" $ }}
+    spec:
+      region: YOUR_REGION
+      auth:
+        secretRef:
+          accessKeyIDSecretRef:
+            name: my-app-ecr-iam
+            key: access-key-id
+          secretAccessKeySecretRef:
+            name: my-app-ecr-iam
+            key: secret-access-key
+  ecr-pull-secret: |
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: my-app-registry-cred
+      namespace: {{ include "app.namespace" $ }}
+    spec:
+      refreshInterval: 6h              # well inside the 12h token lifetime
+      target:
+        name: my-app-registry-cred
+        template:
+          type: kubernetes.io/dockerconfigjson
+          data:
+            .dockerconfigjson: |
+              {
+                "auths": {
+                  "{{ `{{ .proxy_endpoint | replace "https://" "" }}` }}": {
+                    "username": "{{ `{{ .username }}` }}",
+                    "password": "{{ `{{ .password }}` }}",
+                    "auth": "{{ `{{ printf "%s:%s" .username .password | b64enc }}` }}"
+                  }
+                }
+              }
+      dataFrom:
+        - sourceRef:
+            generatorRef:
+              apiVersion: generators.external-secrets.io/v1alpha1
+              kind: ECRAuthorizationToken
+              name: my-app-ecr-token
+```
+
+Replace `my-app` with your application's name throughout (the first ExternalSecret's target is automatically named `<app-name>-ecr-iam`).
+
+:::caution Why the double braces?
+Everything inside `customResourcesMap` is rendered by Helm first, but the `.dockerconfigjson` template lines belong to **external-secrets' own** template engine. The `` {{ `...` }} `` wrappers make Helm emit those placeholders literally so external-secrets can process them. Keep them exactly as shown.
+:::
+
+## Step 4 — Deploy and verify
+
+Commit the values to your deployment-configurations repository and wait for Argo CD to sync (or click **Sync**). In the resource tree you'll see both ExternalSecrets and the `ECRAuthorizationToken`; when they're **Healthy**, the pull secret exists and the application pod starts normally. The token refreshes itself every 6 hours from then on — nothing to renew manually.
+
+If the pod shows **`ImagePullBackOff`**, or the `my-app-registry-cred` ExternalSecret is unhealthy, click it in the Argo CD resource tree and check the events:
+
+- `AccessDenied` / `UnrecognizedClientException` on the ExternalSecret — the IAM key pair is wrong, or the policy is missing `ecr:GetAuthorizationToken`.
+- Pod pulls fail with `403 Forbidden` — the policy's repository ARN doesn't cover the image you're pulling.
+- `SecretSyncedError` mentioning template — the double-brace escaping above was altered; restore it exactly.

--- a/docs/deploy-applications/private-registries/github.md
+++ b/docs/deploy-applications/private-registries/github.md
@@ -1,0 +1,85 @@
+---
+id: registry-github
+title: "GitHub Container Registry (ghcr.io)"
+---
+
+# Pull Images from GitHub Container Registry
+
+Deploy applications whose images live in a **private** GitHub Container Registry (`ghcr.io`) repository. You store a registry credential in your environment's vault once; the platform turns it into a Kubernetes image pull secret that your workloads use automatically.
+
+## Step 1 — Create a GitHub token
+
+Create a [personal access token (classic)](https://github.com/settings/tokens/new?scopes=read:packages&description=glueops-image-pull) with only the **`read:packages`** scope. If the image belongs to an organization that enforces SSO, authorize the token for that organization after creating it.
+
+For organizations, a dedicated machine user (with read access to the package) is preferable to a personal token tied to an individual.
+
+## Step 2 — Compose the Docker config JSON
+
+Build the base64 auth string from `USERNAME:TOKEN` (your GitHub username and the token from Step 1):
+
+```bash
+printf '%s' 'my-github-user:ghp_XXXXXXXX' | base64 -w0
+```
+
+Then the credential document is:
+
+```json
+{
+  "auths": {
+    "ghcr.io": {
+      "auth": "<output of the command above>"
+    }
+  }
+}
+```
+
+## Step 3 — Upload to your vault
+
+In your environment's OpenBao/Vault UI (see [Managing Environment Secrets](/deploy-applications/manage-environment-secrets)), create a secret at a dedicated path:
+
+- Path: `secret/<your-app>-registry-cred`
+- Key `.dockerconfigjson`: the JSON document from Step 2 (as a single value, including the braces)
+
+## Step 4 — Configure your application values
+
+**`base/base-values.yaml`** — point at the private image and name the pull secret:
+
+```yaml
+image:
+  registry: ghcr.io
+  repository: my-org/my-app
+  tag: v1.0.0
+  port: 8080
+  pullSecrets: my-app-registry-cred   # <app-name>-registry-cred
+```
+
+**`envs/prod/values.yaml`** — sync the credential from the vault:
+
+```yaml
+deployment:
+  enabled: true
+  replicas: 1
+
+service:
+  enabled: true
+
+externalSecret:
+  enabled: true
+  secrets:
+    registry-cred:                     # creates Secret <app-name>-registry-cred
+      type: kubernetes.io/dockerconfigjson
+      dataFrom:
+        key: secret/<your-app>-registry-cred
+```
+
+`image.pullSecrets` is inherited by every pod template (Deployment, StatefulSet, Job, CronJob); individual workloads can override it with their own `imagePullSecrets` key if needed.
+
+## Step 5 — Deploy and verify
+
+Commit the values to your deployment-configurations repository and wait for Argo CD to sync (or click **Sync**). The `ExternalSecret` appears in the resource tree and turns **Healthy** once the credential is synced, and the application pod starts normally.
+
+If the pod shows **`ImagePullBackOff`**, click it in the Argo CD resource tree and check the events:
+
+- `unauthorized` / `denied` — the token lacks `read:packages`, isn't SSO-authorized for the organization, or the base64 auth string was built from the wrong `username:token` pair.
+- `manifest unknown` — the image reference (repository/tag) doesn't exist.
+- `pull secret ... not found` — `image.pullSecrets` doesn't match the ExternalSecret's target name (`<app-name>-registry-cred`).

--- a/docs/deploy-applications/private-registries/quay.md
+++ b/docs/deploy-applications/private-registries/quay.md
@@ -1,0 +1,84 @@
+---
+id: registry-quay
+title: "Quay (quay.io)"
+---
+
+# Pull Images from Quay
+
+Deploy applications whose images live in a **private** Quay repository. You store a registry credential in your environment's vault once; the platform turns it into a Kubernetes image pull secret that your workloads use automatically.
+
+## Step 1 — Create a robot account
+
+In Quay, open your organization → **Robot Accounts → Create Robot Account**, then grant it **Read** permission on the repositories your application pulls. Robot account usernames look like `my-org+my-robot`.
+
+(Quay also lets you download a pre-built Kubernetes secret for a robot account — its `.dockerconfigjson` value is exactly what you'll store in the vault in Step 3.)
+
+## Step 2 — Compose the Docker config JSON
+
+Build the base64 auth string from `USERNAME:TOKEN` (the robot account name and its token):
+
+```bash
+printf '%s' 'my-org+my-robot:ROBOT_TOKEN' | base64 -w0
+```
+
+Then the credential document is:
+
+```json
+{
+  "auths": {
+    "quay.io": {
+      "auth": "<output of the command above>"
+    }
+  }
+}
+```
+
+## Step 3 — Upload to your vault
+
+In your environment's OpenBao/Vault UI (see [Managing Environment Secrets](/deploy-applications/manage-environment-secrets)), create a secret at a dedicated path:
+
+- Path: `secret/<your-app>-registry-cred`
+- Key `.dockerconfigjson`: the JSON document from Step 2 (as a single value, including the braces)
+
+## Step 4 — Configure your application values
+
+**`base/base-values.yaml`**
+
+```yaml
+image:
+  registry: quay.io
+  repository: my-org/my-app
+  tag: v1.0.0
+  port: 8080
+  pullSecrets: my-app-registry-cred   # <app-name>-registry-cred
+```
+
+**`envs/prod/values.yaml`**
+
+```yaml
+deployment:
+  enabled: true
+  replicas: 1
+
+service:
+  enabled: true
+
+externalSecret:
+  enabled: true
+  secrets:
+    registry-cred:                     # creates Secret <app-name>-registry-cred
+      type: kubernetes.io/dockerconfigjson
+      dataFrom:
+        key: secret/<your-app>-registry-cred
+```
+
+`image.pullSecrets` is inherited by every pod template (Deployment, StatefulSet, Job, CronJob); individual workloads can override it with their own `imagePullSecrets` key if needed.
+
+## Step 5 — Deploy and verify
+
+Commit the values to your deployment-configurations repository and wait for Argo CD to sync (or click **Sync**). The `ExternalSecret` turns **Healthy** once the credential is synced, and the application pod starts normally.
+
+If the pod shows **`ImagePullBackOff`**, click it in the Argo CD resource tree and check the events:
+
+- `unauthorized: access to the requested resource is not authorized` — the robot account lacks Read on that repository, or the auth string was built from the wrong `robot:token` pair.
+- `pull secret ... not found` — `image.pullSecrets` doesn't match the ExternalSecret's target name (`<app-name>-registry-cred`).

--- a/sidebars.js
+++ b/sidebars.js
@@ -75,6 +75,23 @@ const sidebars = {
             slug: "/custom-domain-certificates",
           },
         },
+        {
+          type: "category",
+          label: "Private Registry Credentials",
+          collapsible: true,
+          items: [
+            "deploy-applications/private-registries/registry-ecr",
+            "deploy-applications/private-registries/registry-github",
+            "deploy-applications/private-registries/registry-dockerhub",
+            "deploy-applications/private-registries/registry-quay",
+          ],
+          link: {
+            type: "generated-index",
+            title: "Private Registry Credentials",
+            description: "Pull images from private container registries — AWS ECR, GitHub Container Registry, Docker Hub, and Quay.",
+            slug: "/private-registry-credentials",
+          },
+        },
       ],
       link: {
         type: "generated-index",


### PR DESCRIPTION
## Summary

New **Private Registry Credentials** section under Developers — pulling images from private registries using only existing app-chart capabilities (`image.pullSecrets` + `externalSecret` values, `customResourcesMap` for ECR):

- **AWS ECR** — ECR tokens expire every 12h, so this page uses external-secrets' [`ECRAuthorizationToken` generator](https://external-secrets.io/latest/api/generator/ecr/): scoped IAM key pair in OpenBao → generator + templated ExternalSecret refresh the pull secret every 6h. The Helm-vs-ESO template escaping (`{{ `{{ .username }}` }}`) is required because `customResourcesMap` goes through `tpl` — validated by rendering the exact example through the app chart.
- **GitHub Container Registry / Docker Hub / Quay** — static `kubernetes.io/dockerconfigjson` credential from OpenBao: token creation per registry, auth JSON composition, vault upload, values, Argo CD verification, ImagePullBackOff troubleshooting. (Docker Hub page notes the `https://index.docker.io/v1/` auth host and the rate-limit benefit for public pulls.)

All verification steps use the Argo CD UI flow (no kubectl), matching the Custom Domain Certificates section.

## Testing

- `npm run build` passes (`onBrokenLinks: "throw"`).
- Both example shapes (ECR generator via `customResourcesMap`, static dockerconfigjson via `externalSecret`) rendered through the actual project-template-helm-chart-app chart — output verified well-formed, including literal ESO placeholders and `imagePullSecrets` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)